### PR TITLE
Doc: Allow mkdocs to work with ATX headings

### DIFF
--- a/doc/mkdocs/build.sh
+++ b/doc/mkdocs/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # Split lua_api.md on top level headings
-cat ../lua_api.md | csplit -sz -f docs/section - '/^=/-1' '{*}'
+cat ../lua_api.md | csplit -sz -f docs/section - '/^# /' '{*}'
 
 cat > mkdocs.yml << EOF
 site_name: Minetest API Documentation
@@ -30,6 +30,7 @@ mv docs/section00 docs/index.md
 for f in docs/section*
 do
 	title=$(head -1 $f)
+    title="${title#??}"
 	fname=$(echo $title | tr '[:upper:]' '[:lower:]')
 	fname=$(echo $fname | sed 's/ /-/g')
 	fname=$(echo $fname | sed "s/'//g").md


### PR DESCRIPTION
To use the "modern" headings, the mkdocs build script must be updated accordingly to reflect this.

# Test

1. obtain mkdocs, and the deps
2. build docs by running `sh build.sh` in the `$minetest/doc/mkdocs` directory
3. run a simple HTTP server to more easily inspect generated docs at `$minetest/public` directory